### PR TITLE
Fix link for "Modify an image to a single layer"

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ This guide is intended to be a point of knowledge for everyone who wants to pass
 - [Utilize a registry to store an image](https://docs.docker.com/registry/deploying/#copy-an-image-from-docker-hub-to-your-registry)
 - [Display layers of a Docker image](http://blog.arungupta.me/show-layers-of-docker-image/)
 - [Apply a file to create a Docker image](https://docs.docker.com/engine/reference/commandline/image_load/)
-- [Modify an image to a single layer](https://docs.docker.com/engine/reference/commandline/save/)
+- [Modify an image to a single layer](https://tuhrig.de/flatten-a-docker-container-or-image/)
 - [Describe how image layers work](https://medium.com/@jessgreb01/digging-into-docker-layers-c22f948ed612)
 - [Deploy a registry (not architect)](https://docs.docker.com/registry/deploying/)
 - [Configure a registry](https://docs.docker.com/registry/configuration/)


### PR DESCRIPTION
`docker image save` command does not flatten an image, it keeps a history which we want to get rid of.
Link provided by me explains how to make single layer from whole image.