### PR TITLE
The exam website is changed

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ the filesystem](https://docs.docker.com/storage/storagedriver/#images-and-layers
 
 ## Links
 
-- [About the exam](https://success.docker.com/Certification)
+- [About the exam](https://success.mirantis.com/certification)
 - [Official study guide (PDF)](https://docker.cdn.prismic.io/docker/4a619747-6889-48cd-8420-60f24a6a13ac_DCA_study+Guide_v1.3.pdf)
 
 ## Contributors


### PR DESCRIPTION
The new website is https://success.mirantis.com/certification
The old one is https://success.docker.com/Certification